### PR TITLE
Silence ringer during recording transition

### DIFF
--- a/src/es/esy/CosyDVR/BackgroundVideoRecorder.java
+++ b/src/es/esy/CosyDVR/BackgroundVideoRecorder.java
@@ -455,8 +455,11 @@ public class BackgroundVideoRecorder extends Service implements
 		AudioManager manager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
 		manager.setStreamSolo(AudioManager.STREAM_SYSTEM, true);
 		manager.setStreamMute(AudioManager.STREAM_SYSTEM, true);
+		int savedRingerMode = manager.getRingerMode();
+		manager.setRingerMode(AudioManager.RINGER_MODE_SILENT);
 		StopRecording();
 		StartRecording();
+		manager.setRingerMode(savedRingerModer);
 		manager.setStreamMute(AudioManager.STREAM_SYSTEM, false);
 		manager.setStreamSolo(AudioManager.STREAM_SYSTEM, false);
 	}


### PR DESCRIPTION
MediaRecorder produces a "chime" sound on state changes (e.g. on the
stop and start of recordings). Some versions of Android use
STREAM_SYSTEM to produce the sound, but others such as version 4.2.1 on
the Galaxy Nexus use STREAM_RING. This patch silences the ringer during
recording transitions in order to prevent the "chime" sound from being
heard on each RestartRecording method call on relevant Android versions.